### PR TITLE
recognize singlequote strings

### DIFF
--- a/autoload/starlark.vim
+++ b/autoload/starlark.vim
@@ -44,6 +44,7 @@ function! starlark#set_syntax(contained) abort
 
   exec 'syn region starlarkString start=+"+ skip=+\\\\\|\\"+ end=+"+ ' . l:option
   exec 'syn region starlarkString start=+`+ end=+`+ ' . l:option
+  exec "syn region starlarkString start=+'+ end=+'+ " . l:option
 
   hi def link starlarkString String
 


### PR DESCRIPTION
not sure if the syntax is correct.
`skip=+\\\\\|\\"+` this part you have on double quoted strings is quite confusing.

But  anyways, it would be nice to also recognize singlequoted strings as strings.
